### PR TITLE
Restore full image and set default selected image size to large

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -220,17 +220,17 @@ add_filter('post-upload-ui', 'warning_size_image');
  * https://gist.github.com/wycks/4949242
  */
 
-function add_image_insert_override($size_names){
-        $size_names = array(
-                          'thumbnail' => __('Thumbnail'),
-                          'medium'    => __('Medium'),
-                          'large'     => __('Large'),
-                        );
-      return $size_names;
-};
+/**
+ * Set default selected media size to "large". 
+ * If large size not exists, select Original size. 
+ * @author Xavier Meler (jmeler@xtec.cat)
+ */
 
-add_filter('image_size_names_choose', 'add_image_insert_override' );
+function default_image_size (){
+    return 'large';
+}
 
+add_filter('pre_option_image_default_size','default_image_size');
 
 /**
  * RSS Shortcode


### PR DESCRIPTION
S'ha restaurat la opció "Mida Original" quan es puja una foto i s'ha establert per defecte la mida "Gran". 

**Test:** 
Pujar fotos de mida més gran de 1024 i veure que la mediateca proposa la mida "Gran" enlloc de la mida "Original". 
Pujar fotos més petites de 1024 i veure que proposa la mida "Original".
