### PR TITLE
Allow shortcodes to category description

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -654,6 +654,14 @@ function multiple_categories( $query ) {
 }
 
 /**
+ * Load shortcodes into description to category, tags and taxonomies
+ *
+ * @author Xavi Nieto
+ */
+add_filter( 'term_description', 'shortcode_unautop');
+add_filter( 'term_description', 'do_shortcode');
+
+/**
  * Deactivate pingback to avoid attacks to other sites
  *
  * @author Toni Ginard


### PR DESCRIPTION
Permetre introduir mitjançant "shortcodes" introduir google calendar, carrusel, etc a la descripcions de categories, tags i taxonomies.

Aquesta modificació afecta tant a "Agora-Nodes" com a "xtecblocs".

Per provar la modificació cal anar a una categoria i en el camp de descripció cap afegir amb shortcodes un carrusel i un google calendar.
