### PR TITLE
Not modify embed code visual editor

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -747,3 +747,22 @@ add_filter( 'xmlrpc_methods', function( $methods ) {
     unset( $methods['pingback.ping'] );
     return $methods;
 }, 1 );
+
+/**
+ * Add flashvars to valid elements for tinymc
+ *
+ * @author Xavier Nieto
+ */
+function add_flashvars_tinymc( $init ) {
+
+    $ext = 'embed[width|height|name|flashvars|src|bgcolor|align|play|loop|quality|allowscriptaccess|type|pluginspage]';
+
+    if ( isset( $init['extended_valid_elements'] ) ) {
+        $init['extended_valid_elements'] .= ',' . $ext;
+    } else {
+        $init['extended_valid_elements'] = $ext;
+    }
+
+    return $init;
+}
+add_filter('tiny_mce_before_init', 'add_flashvars_tinymc');


### PR DESCRIPTION
**Solució:**

Habilitar al tinymce que la extensió de embed no la modifiqui al canviar al mode "visual", i per tant que permeti els seus atributs.

**Per tal de provar-ho:**
- Provar a insertar un embed al tinymce en mode "text".
- Canviar al mode "visual" al tinymce i publicar.
- Visualitzar l'articles (en cas de Nodes) o l'entrada (en xtecblocs) i comprovar que es visualitza el codi correctament a la part pública.

Exemple embed:

`<embed type="application/x-shockwave-flash" src="https://photos.gstatic.com/media/slideshow.swf" width="288" height="192" flashvars="host=picasaweb.google.com&hl=en_US&feat=flashalbum&RGB=0x000000&feed=https%3A%2F%2Fpicasaweb.google.com%2Fdata%2Ffeed%2Fapi%2Fuser%2F118376620560159700965%2Falbumid%2F6300212854719701953%3Falt%3Drss%26kind%3Dphoto%26hl%3Den_US" pluginspage="http://www.macromedia.com/go/getflashplayer"></embed>`
