### PR TITLE
Fix default comment status. Restore default action about comment status parameter.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -98,10 +98,8 @@ add_action('add_meta_boxes', 'set_order_meta_boxes', 10, 2);
  */
 function default_comments_off( $data ) {
 	if( $data['post_type'] == 'page' && $data['post_status'] == 'auto-draft' ) {
-		$data['comment_status'] = 'close';
         $data['ping_status'] = 'close';
     }elseif ( $data['post_type'] == 'post' && $data['post_status'] == 'auto-draft' ) {
-    	$data['comment_status'] = 'open';
     	$data['ping_status'] = 'open';
     }
 	return $data;


### PR DESCRIPTION
Hem refet el comportament per defecte dels comentaris a WordPress.

Quan es crea un article nou, el checkbox dels articles que deixen comentar, es marca en funció de l'opció seleccionada en Opcions | Debats | Permet a la gent fer comentaris als articles nous .

Quan es crea una pàgina, per defecte aquesta opció apareix desmarcada.

Prova:
- Canviar el paràmetre general a:  Opcions | Debats | Permet a la gent fer comentaris als articles nous.
- Crear un article nou, i veure que es crea segons el paràmetre indicat. Desar l'article canviant el checkbox i veure que manté la opció escollida.
- Crear una pagina nova, i veure que es crea sempre amb la opció desmarcada. Desar la pagina canviant el checkbox i veure que manté la opció escollida.
