### PR TITLE
Wip hidden metaboxes simple calendar

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -773,3 +773,17 @@ function xtec_allowed_external_host( $allow, $host, $url ) {
     return $allow;
 }
 add_filter('http_request_host_is_external', 'xtec_allowed_external_host', 10, 3);
+
+// Simple Calendar
+
+/**
+ * Hidden some metaboxes to nav-menus
+ *
+ * @author Xavier Nieto
+ */
+function remove_nav_menu_metaboxes( $metaboxes ){
+    if ( ! is_xtec_super_admin() ) {
+        remove_meta_box('add-calendar_category', 'nav-menus', 'side');
+    }
+}
+add_action( 'admin_head-nav-menus.php', 'remove_nav_menu_metaboxes', 10, 1 );

--- a/lib.php
+++ b/lib.php
@@ -17,8 +17,6 @@ function remove_post_meta_boxes() {
 	remove_meta_box('trackbacksdiv', 'post', 'side');
 	remove_meta_box('postcustom', 'post', 'normal');
 	remove_meta_box('postcustom', 'post', 'side');
-	remove_meta_box('rawhtml_meta_box', 'post', 'side');
-	remove_meta_box('rawhtml_meta_box', 'post', 'normal');
 	remove_meta_box('layout_meta', 'post', 'side');
 	remove_meta_box('layout_meta', 'post', 'normal');
 }
@@ -29,8 +27,6 @@ add_action('do_meta_boxes', 'remove_post_meta_boxes');
  * @author Xavi Meler
  */
 function remove_page_meta_boxes() {
-	remove_meta_box('rawhtml_meta_box', 'page', 'normal');
-	remove_meta_box('rawhtml_meta_box', 'page', 'side');
 	remove_meta_box('postcustom', 'page', 'normal');
 	remove_meta_box('postimagediv', 'page', 'side');
 }


### PR DESCRIPTION
1r commit: Eliminar codi que referència a un plugin desinstal·lat.
2n commit: Eliminar el meta_box per tal de no poder escollir la categoria de calendari com a menú.

Proves: 

1. Provar amb un usuari diferent al xtec_admin, i anar a Aparença | Menú i veure que només hi ha un checkbox amb el nom Categories.
2. Provar amb usuari xtec_admin, i anar a Aparença | Menú i veure que hi han 2 checkbox amb el nom Categories.
